### PR TITLE
update pyyaml dependency to 5.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     cfgv>=2.0.0
     identify>=1.0.0
     nodeenv>=0.11.1
-    pyyaml>=5.1
+    pyyaml>=5.4
     toml
     virtualenv>=20.0.8
     importlib-metadata;python_version<"3.8"


### PR DESCRIPTION
This PR updates the minimum PyYAML version to 5.4, which remediates [CVE-2020-14343](https://access.redhat.com/security/cve/cve-2020-14343), as noted in the [5.4 Changelog](https://github.com/yaml/pyyaml/blob/master/CHANGES#L14).